### PR TITLE
Remove unnecessary packer vars symlinks

### DIFF
--- a/packer/vars/centos7
+++ b/packer/vars/centos7
@@ -1,1 +1,0 @@
-../common-packer/vars/centos-7.json

--- a/packer/vars/centos8
+++ b/packer/vars/centos8
@@ -1,1 +1,0 @@
-../common-packer/vars/centos-8.json

--- a/packer/vars/ubuntu-20.04.json
+++ b/packer/vars/ubuntu-20.04.json
@@ -1,1 +1,0 @@
-../common-packer/vars/ubuntu-20.04.json


### PR DESCRIPTION
Due to how packer-build.sh works, these symlinks are unnecessary.
Because the script will use the common-packer versions if the local
vars files aren't present, there is no need for symlinks to the
common-packer versions.

Issue: IT-21829
Signed-off-by: Eric Ball <eball@linuxfoundation.org>