### PR TITLE
Remove "/sandbox" from jenkins.ini.example

### DIFF
--- a/jenkins.ini.example
+++ b/jenkins.ini.example
@@ -7,5 +7,5 @@ recursive=True
 [jenkins]
 user=#LFID#
 password=#api_token#
-url=https://jenkins.lfedge.org/sandbox
+url=https://jenkins.lfedge.org
 query_plugins_info=False

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -1,6 +1,6 @@
 ---
 # LF Edge JJB template variable default values
-
+# Arbitrary change
 - defaults:
     name: global
 


### PR DESCRIPTION
There is no sandbox for LF Edge.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>